### PR TITLE
Make MJCF paths absolute in example scripts

### DIFF
--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -12,6 +12,7 @@ The testing methodology is as follows:
 
 import mujoco
 import numpy as np
+import os
 import time
 
 from mj_maniPlan.rrt import (
@@ -24,7 +25,8 @@ import mj_maniPlan.utils as utils
 
 if __name__ == '__main__':
     # NOTE: modify these parameters as needed for your benchmarking needs.
-    model_xml_path = 'models/franka_emika_panda/scene.xml'
+    dir = os.path.dirname(os.path.realpath(__file__))
+    model_xml_path = dir + "/../models/franka_emika_panda/scene.xml"
     # The joints to sample during planning.
     joint_names = [
         'joint1',

--- a/examples/simulate.py
+++ b/examples/simulate.py
@@ -5,6 +5,7 @@ Example of how to generate a path and visualize the path waypoints.
 import mujoco
 import mujoco.viewer
 import numpy as np
+import os
 import time
 
 from mj_maniPlan.rrt import (
@@ -16,7 +17,9 @@ import mj_maniPlan.utils as utils
 
 
 if __name__ == '__main__':
-    model = mujoco.MjModel.from_xml_path('models/franka_emika_panda/scene_with_obstacles.xml')
+    dir = os.path.dirname(os.path.realpath(__file__))
+    model_xml_path = dir + "/../models/franka_emika_panda/scene_with_obstacles.xml"
+    model = mujoco.MjModel.from_xml_path(model_xml_path)
     data = mujoco.MjData(model)
 
     # The joints to sample during planning.


### PR DESCRIPTION
The example scripts were using a relative path to the MJCF files, which meant that they could only be executed from the root of this repo. Using absolute paths allows the example scripts to be executed from anywhere on the user's machine.