### PR TITLE
Remove set_path_root API

### DIFF
--- a/test/test_rrt.py
+++ b/test/test_rrt.py
@@ -80,8 +80,7 @@ class TestRRT(unittest.TestCase):
             expected_q_extended,
             self.q_init,
         ]
-        tree.set_path_root(extended_node)
-        path = tree.get_path()
+        path = tree.get_path(extended_node)
         self.assertEqual(len(path), len(expected_path))
         for i in range(len(path)):
             self.assertAlmostEqual(path[i][0], expected_path[i][0], places=9)
@@ -128,8 +127,7 @@ class TestRRT(unittest.TestCase):
         # Check the path from the last connected node.
         # This implicitly checks each connected node's parent.
         expected_path = expected_qs_in_tree[::-1]
-        tree.set_path_root(goal_node)
-        path = tree.get_path()
+        path = tree.get_path(goal_node)
         self.assertEqual(len(path), len(expected_path))
         for i in range(len(path)):
             self.assertAlmostEqual(path[i][0], expected_path[i][0], places=9)
@@ -172,14 +170,12 @@ class TestRRT(unittest.TestCase):
         start_tree = rrt.Tree()
         start_tree.add_node(rrt.Node(self.q_init, None))
         connected_node_a = self.planner.connect(q_new, start_tree)
-        start_tree.set_path_root(connected_node_a)
 
         goal_tree = rrt.Tree()
         goal_tree.add_node(rrt.Node(np.array([0.5]), None))
         connected_node_b = self.planner.connect(q_new, goal_tree)
-        goal_tree.set_path_root(connected_node_b)
 
-        path = self.planner.get_path(start_tree, goal_tree)
+        path = self.planner.get_path(start_tree, connected_node_a, goal_tree, connected_node_b)
         expected_path = [
             self.q_init,
             np.array([0.0]),
@@ -244,8 +240,7 @@ class TestRRT(unittest.TestCase):
         for n in nodes:
             tree.add_node(n)
 
-        tree.set_path_root(n_7)
-        path = tree.get_path()
+        path = tree.get_path(n_7)
         path.reverse()
         self.assertEqual(len(path), len(nodes))
         for i in range(len(path)):

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -63,16 +63,15 @@ class TestTree(unittest.TestCase):
     def test_get_path(self):
         self.build_tree()
 
-        # error should occur if the path root node has not been set
-        with self.assertRaisesRegex(ValueError, "path root node has not been set"):
-            self.tree.get_path()
+        # error should occur if the path root node is not a part of the Tree
+        orphan_node = Node(np.array([5, 5]), None)
+        with self.assertRaisesRegex(ValueError, "Called get_path starting from a node that is not in the tree"):
+            self.tree.get_path(orphan_node)
 
-        self.tree.set_path_root(self.n_3)
-        path = self.tree.get_path()
+        path = self.tree.get_path(self.n_3)
         self.assertTrue(np.array_equal(path, [self.n_3.q, self.n_1.q, self.n_0.q]))
 
-        self.tree.set_path_root(self.n_0)
-        path = self.tree.get_path()
+        path = self.tree.get_path(self.n_0)
         self.assertTrue(np.array_equal(path, [self.n_0.q]))
 
 


### PR DESCRIPTION
The `Tree` class requires specifying the root of the path (a `Node` object) when calling `get_path`. This was previously done via a separate `get_path_root` method, but it's simpler to pass the path root Node to the `get_path` method directly.