### PR TITLE
Remove references to adding support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # TODO (#28): add 3.9 here if project supports it
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
   "numpy",
   "ruckig",
 ]
-# TODO (#28): change to 3.9 if project supports it
 requires-python = ">=3.10"
 authors = [
   { name="Ashton Larkin", email="" },
@@ -47,7 +46,6 @@ all = [
 Homepage = "https://github.com/adlarkin/mj_maniPlan"
 
 [tool.ruff]
-# TODO (#28): change to 3.9 (py39) if project supports it
 target-version = "py310"
 
 [tool.ruff.lint]


### PR DESCRIPTION
Closes #28

As mentioned in #28, it's probably not worth the effort to support python 3.9 if this project already supports python >= 3.10