### PR TITLE
Use ruff for formatting (remove black)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      - name: Linter (Ruff)
+      - name: Lint
         run: ruff check .
 
-      - name: Formatter (black)
-        run: black --check .
+      - name: Format
+        run: ruff format --diff .
 
       - name: Run tests
         run: python -m unittest -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,10 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.6  # Use the latest stable version of Ruff
+    rev: v0.9.6
     hooks:
       - id: ruff
+      - id: ruff-format
 
-  - repo: https://github.com/psf/black
-    rev: 25.1.0  # Use the latest stable version of Black
-    hooks:
-      - id: black
-
-  # Custom local hook to run unit tests before commit
   - repo: local
     hooks:
       - id: run-tests

--- a/README.md
+++ b/README.md
@@ -21,20 +21,20 @@ For local development, install the developer dependencies:
 pip3 install -e ".[dev]"
 ```
 
-This project uses [Ruff](https://docs.astral.sh/ruff/) for linting and [Black](https://black.readthedocs.io/en/stable/) for formatting.
+This project uses [Ruff](https://docs.astral.sh/ruff/) for linting and formatting.
 Unit tests are written via the [unittest](https://docs.python.org/3/library/unittest.html) framework.
 
 To run the linter, formatter, and tests locally:
-```
+```bash
 # Check for linter errors
 ruff check .
 # Apply lint fixes
 ruff check --fix .
 
-# Check for formatting errors
-black --check .
+# Check for format errors
+ruff format --diff .
 # Apply format fixes
-black .
+ruff format .
 
 # Run unit tests
 python3 -m unittest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ test = [
   "robot_descriptions",
 ]
 dev = [
-  "black",
   "mjpl[test]",
   "pre-commit",
   "ruff",


### PR DESCRIPTION
This makes tooling a little more uniform (same thing for lint/format) and also removes `black` as a dependency