### PR TITLE
explicitly list all joints

### DIFF
--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
 
         # From the initial state, generate a goal pose.
         data = mujoco.MjData(model)
-        data.qpos = mjpl.random_valid_config(model, q_init, seed, planning_joints, cr)
+        data.qpos = mjpl.random_valid_config(model, q_init, planning_joints, seed, cr)
         mujoco.mj_kinematics(model, data)
         goal_pose = mjpl.site_pose(data, _PANDA_EE_SITE)
 

--- a/examples/franka_move_to_pose.py
+++ b/examples/franka_move_to_pose.py
@@ -47,7 +47,7 @@ def main():
     # valid joint configuration.
     data = mujoco.MjData(model)
     mujoco.mj_resetDataKeyframe(model, data, home_keyframe.id)
-    data.qpos = mjpl.random_valid_config(model, q_init, seed, arm_joints, cr)
+    data.qpos = mjpl.random_valid_config(model, q_init, arm_joints, seed, cr)
     mujoco.mj_kinematics(model, data)
     goal_pose = mjpl.site_pose(data, _PANDA_EE_SITE)
 

--- a/examples/franka_plan_to_multiple_poses.py
+++ b/examples/franka_plan_to_multiple_poses.py
@@ -53,7 +53,7 @@ def main():
     for i in range(_NUM_GOALS):
         # Make sure a different seed is used for each randomly generated config
         _seed = seed + i if seed is not None else seed
-        data.qpos = mjpl.random_valid_config(model, q_init, _seed, arm_joints, cr)
+        data.qpos = mjpl.random_valid_config(model, q_init, arm_joints, _seed, cr)
         mujoco.mj_kinematics(model, data)
         goal_poses.append(mjpl.site_pose(data, _PANDA_EE_SITE))
 

--- a/examples/ur5_cartesian_move.py
+++ b/examples/ur5_cartesian_move.py
@@ -33,14 +33,7 @@ def main():
     model = mujoco.MjModel.from_xml_path(_UR5_XML.as_posix())
     data = mujoco.MjData(model)
 
-    arm_joints = [
-        "shoulder_pan_joint",
-        "shoulder_lift_joint",
-        "elbow_joint",
-        "wrist_1_joint",
-        "wrist_2_joint",
-        "wrist_3_joint",
-    ]
+    arm_joints = mjpl.all_joints(model)
     q_idx = mjpl.qpos_idx(model, arm_joints)
 
     cr = mjpl.CollisionRuleset(model)
@@ -72,7 +65,7 @@ def main():
 
     print("Planning...")
     start = time.time()
-    path = mjpl.cartesian_plan(q_init, poses, _UR5_EE_SITE, solver)
+    path = mjpl.cartesian_plan(model, q_init, poses, _UR5_EE_SITE, solver)
     if path is None:
         print("Planning failed")
         return

--- a/examples/ur5_move_to_config.py
+++ b/examples/ur5_move_to_config.py
@@ -21,14 +21,7 @@ def main():
 
     model = mujoco.MjModel.from_xml_path(_UR5_XML.as_posix())
 
-    arm_joints = [
-        "shoulder_pan_joint",
-        "shoulder_lift_joint",
-        "elbow_joint",
-        "wrist_1_joint",
-        "wrist_2_joint",
-        "wrist_3_joint",
-    ]
+    arm_joints = mjpl.all_joints(model)
     q_idx = mjpl.qpos_idx(model, arm_joints)
 
     cr = mjpl.CollisionRuleset(model)
@@ -40,7 +33,7 @@ def main():
     # From the initial state, generate a valid goal configuration.
     data = mujoco.MjData(model)
     mujoco.mj_resetDataKeyframe(model, data, home_keyframe.id)
-    q_goal = mjpl.random_valid_config(model, q_init, seed, arm_joints, cr)
+    q_goal = mjpl.random_valid_config(model, q_init, arm_joints, seed, cr)
 
     # Set up the planner.
     planner = mjpl.RRT(model, arm_joints, cr, seed=seed, goal_biasing_probability=0.1)

--- a/src/mjpl/__init__.py
+++ b/src/mjpl/__init__.py
@@ -9,7 +9,7 @@ from .trajectory import (
     ToppraTrajectoryGenerator,
     generate_collision_free_trajectory,
 )
-from .utils import qpos_idx, random_valid_config, shortcut, site_pose
+from .utils import all_joints, qpos_idx, random_valid_config, shortcut, site_pose
 
 __all__ = (
     "CollisionRuleset",
@@ -17,6 +17,7 @@ __all__ = (
     "RRT",
     "RuckigTrajectoryGenerator",
     "ToppraTrajectoryGenerator",
+    "all_joints",
     "cartesian_plan",
     "generate_collision_free_trajectory",
     "qpos_idx",

--- a/src/mjpl/inverse_kinematics/mink_ik_solver.py
+++ b/src/mjpl/inverse_kinematics/mink_ik_solver.py
@@ -13,7 +13,7 @@ class MinkIKSolver(IKSolver):
     def __init__(
         self,
         model: mujoco.MjModel,
-        joints: list[str] = [],
+        joints: list[str],
         cr: CollisionRuleset | None = None,
         pos_tolerance: float = 1e-3,
         ori_tolerance: float = 1e-3,
@@ -27,8 +27,7 @@ class MinkIKSolver(IKSolver):
         Args:
             model: MuJoCo model.
             joints: The joints to use when generating initial states for new solve
-                attempts and validating configurations. An empty list means all
-                joints will be used.
+                attempts and validating configurations.
             cr: The collision rules to enforce. If defined, IK solutions must
                 also obey this ruleset.
             pos_tolerance: Allowed position error.
@@ -40,6 +39,8 @@ class MinkIKSolver(IKSolver):
             solver: Solver to use, which comes from the qpsolvers package:
                 https://github.com/qpsolvers/qpsolvers
         """
+        if not joints:
+            raise ValueError("`joints` cannot be empty.")
         if max_attempts < 1:
             raise ValueError("`max_attempts` must be > 0.")
         if iterations < 1:
@@ -97,7 +98,7 @@ class MinkIKSolver(IKSolver):
             # Make sure a different seed is used for each randomly generated config.
             _seed = self.seed + attempt if self.seed is not None else self.seed
             next_guess = utils.random_valid_config(
-                self.model, configuration.q, _seed, self.joints, self.cr
+                self.model, configuration.q, self.joints, _seed, self.cr
             )
             configuration.update(next_guess)
         return None

--- a/src/mjpl/planning/cartesian_planner.py
+++ b/src/mjpl/planning/cartesian_planner.py
@@ -1,9 +1,11 @@
+import mujoco
 import numpy as np
 from mink.lie import SE3, SO3
 from scipy.spatial.transform import Rotation, Slerp
 
 from ..inverse_kinematics.ik_solver import IKSolver
 from ..types import Path
+from ..utils import all_joints
 
 
 def _interpolate_poses(
@@ -59,6 +61,7 @@ def _interpolate_poses(
 
 
 def cartesian_plan(
+    model: mujoco.MjModel,
     q_init_world: np.ndarray,
     poses: list[SE3],
     site: str,
@@ -69,6 +72,7 @@ def cartesian_plan(
     """Plan joint configurations that satisfy a Cartesian path.
 
     Args:
+        model: MuJoCo model.
         q_init_world: Initial joint configuration of the world.
         poses: The Cartesian path. These poses should be in the world frame.
         site: The site (i.e., frame) that should follow the Cartesian path.
@@ -96,4 +100,4 @@ def cartesian_plan(
             print(f"Unable to find a joint configuration for pose {p}")
             return None
         waypoints.append(q)
-    return Path(q_init=q_init_world, waypoints=waypoints, joints=[])
+    return Path(q_init=q_init_world, waypoints=waypoints, joints=all_joints(model))

--- a/src/mjpl/planning/rrt.py
+++ b/src/mjpl/planning/rrt.py
@@ -36,8 +36,7 @@ class RRT:
 
         Args:
             model: MuJoCo model.
-            planning_joints: The joints used for planning. An empty list means all
-                joints will be used.
+            planning_joints: The joints used for planning.
             cr: The CollisionRuleset the sampled configurations must obey.
             max_planning_time: Maximum planning time, in seconds.
             epsilon: The maximum distance allowed between nodes in the tree.
@@ -47,6 +46,8 @@ class RRT:
                 This must be a value between [0.0, 1.0].
             max_connection_distance: The maximum distance for extending a tree using CONNECT.
         """
+        if not planning_joints:
+            raise ValueError("`planning_joints` cannot be empty.")
         if max_planning_time <= 0.0:
             raise ValueError("`max_planning_time` must be > 0.0")
         if epsilon <= 0.0:
@@ -58,7 +59,7 @@ class RRT:
 
         self.model = model
         self.planning_joints = planning_joints
-        self.q_idx = utils.qpos_idx(model, planning_joints, default_to_full=True)
+        self.q_idx = utils.qpos_idx(model, planning_joints)
         self.cr = cr
         self.max_planning_time = max_planning_time
         self.epsilon = epsilon

--- a/src/mjpl/trajectory/trajectory_interface.py
+++ b/src/mjpl/trajectory/trajectory_interface.py
@@ -17,7 +17,6 @@ class Trajectory:
     # Initial configuration of all joints.
     q_init: np.ndarray
     # The joints corresponding to `positions`, `velocities`, and `accelerations`.
-    # An empty list means all joints are used.
     joints: list[str]
     # The timestep between each position, velocity, and acceleration snapshot.
     dt: float
@@ -27,6 +26,10 @@ class Trajectory:
     velocities: list[np.ndarray]
     # Acceleration snapshots at increments of dt, ranging from t = [dt, t_f]
     accelerations: list[np.ndarray]
+
+    def __post_init__(self) -> None:
+        if not self.joints:
+            raise ValueError("`joints` cannot be empty.")
 
 
 class TrajectoryGenerator(ABC):

--- a/src/mjpl/trajectory/utils.py
+++ b/src/mjpl/trajectory/utils.py
@@ -40,7 +40,7 @@ def generate_collision_free_trajectory(
     while True:
         traj = generator.generate_trajectory(path)
         data.qpos = traj.q_init
-        q_idx = utils.qpos_idx(model, traj.joints, default_to_full=True)
+        q_idx = utils.qpos_idx(model, traj.joints)
         for i in range(len(traj.positions)):
             q = traj.positions[i]
             data.qpos[q_idx] = q
@@ -71,8 +71,8 @@ def _waypoint_timing(
     Returns:
         A list of timestamps for each waypoint in `waypoints` based on `trajectory`.
     """
-    if not waypoints:
-        return []
+    if len(waypoints) < 2:
+        raise ValueError("There must be at least two waypoints defined.")
 
     # The first waypoint maps to time 0.0
     timestamps = [0.0]

--- a/src/mjpl/types.py
+++ b/src/mjpl/types.py
@@ -12,5 +12,8 @@ class Path:
     # Configurations for `joints` that define a path, starting at `q_init`.
     waypoints: list[np.ndarray]
     # The joints corresponding to `waypoints`.
-    # An empty list means all joints are used.
     joints: list[str]
+
+    def __post_init__(self) -> None:
+        if not self.joints:
+            raise ValueError("`joints` cannot be empty.")

--- a/test/test_rrt.py
+++ b/test/test_rrt.py
@@ -20,42 +20,39 @@ class TestRRT(unittest.TestCase):
         q_init = np.array([-0.2])
         q_goal = np.array([0.35])
 
-        # Planning for all joints can be done by explicitly listing all joints, or by
-        # using an empty list for `planning_joints`.
-        for planning_joints in (["ball_slide_x"], []):
-            planner = mjpl.RRT(
-                model,
-                planning_joints,
-                cr,
-                max_planning_time=5.0,
-                epsilon=epsilon,
-                seed=42,
+        planner = mjpl.RRT(
+            model,
+            mjpl.all_joints(model),
+            cr,
+            max_planning_time=5.0,
+            epsilon=epsilon,
+            seed=42,
+        )
+        path = planner.plan_to_config(q_init, q_goal)
+        self.assertIsNotNone(path)
+        np.testing.assert_equal(path.q_init, q_init)
+        self.assertGreater(len(path.waypoints), 2)
+        self.assertListEqual(path.joints, mjpl.all_joints(model))
+
+        # The path should start at q_init and end at q_goal.
+        np.testing.assert_equal(path.waypoints[0], q_init)
+        np.testing.assert_equal(path.waypoints[-1], q_goal)
+
+        # Subsequent waypoints should be no further than epsilon apart.
+        for i in range(1, len(path.waypoints)):
+            self.assertLessEqual(
+                np.linalg.norm(path.waypoints[i] - path.waypoints[i - 1]),
+                epsilon,
             )
-            path = planner.plan_to_config(q_init, q_goal)
-            self.assertIsNotNone(path)
-            np.testing.assert_equal(path.q_init, q_init)
-            self.assertGreater(len(path.waypoints), 2)
-            self.assertListEqual(path.joints, planning_joints)
 
-            # The path should start at q_init and end at q_goal.
-            np.testing.assert_equal(path.waypoints[0], q_init)
-            np.testing.assert_equal(path.waypoints[-1], q_goal)
-
-            # Subsequent waypoints should be no further than epsilon apart.
-            for i in range(1, len(path.waypoints)):
-                self.assertLessEqual(
-                    np.linalg.norm(path.waypoints[i] - path.waypoints[i - 1]),
-                    epsilon,
-                )
-
-            # The path's initial state and all waypoints should be valid configs.
-            data = mujoco.MjData(model)
-            data.qpos = path.q_init
+        # The path's initial state and all waypoints should be valid configs.
+        data = mujoco.MjData(model)
+        data.qpos = path.q_init
+        self.assertTrue(mjpl.utils.is_valid_config(model, data, cr))
+        q_idx = mjpl.qpos_idx(model, mjpl.all_joints(model))
+        for wp in path.waypoints:
+            data.qpos[q_idx] = wp
             self.assertTrue(mjpl.utils.is_valid_config(model, data, cr))
-            q_idx = mjpl.qpos_idx(model, planning_joints, default_to_full=True)
-            for wp in path.waypoints:
-                data.qpos[q_idx] = wp
-                self.assertTrue(mjpl.utils.is_valid_config(model, data, cr))
 
     def test_trivial_rrt(self):
         model = mujoco.MjModel.from_xml_path(_BALL_XML.as_posix())
@@ -67,31 +64,39 @@ class TestRRT(unittest.TestCase):
 
         # Plan to a goal that is immediately reachable.
         planner = mjpl.RRT(
-            model, [], cr, max_planning_time=5.0, epsilon=epsilon, seed=42
+            model,
+            mjpl.all_joints(model),
+            cr,
+            max_planning_time=5.0,
+            epsilon=epsilon,
+            seed=42,
         )
         path = planner.plan_to_config(q_init, q_goal)
         self.assertIsNotNone(path)
         self.assertEqual(len(path.waypoints), 2)
         np.testing.assert_equal(path.waypoints[0], q_init)
         np.testing.assert_equal(path.waypoints[1], q_goal)
-        self.assertListEqual(path.joints, [])
+        self.assertListEqual(path.joints, mjpl.all_joints(model))
 
     def test_invalid_args(self):
         model = mujoco.MjModel.from_xml_path(_BALL_XML.as_posix())
+        joints = mjpl.all_joints(model)
         cr = mjpl.CollisionRuleset(model)
 
         with self.assertRaisesRegex(ValueError, "max_planning_time"):
-            mjpl.RRT(model, [], cr, max_planning_time=0.0)
-            mjpl.RRT(model, [], cr, max_planning_time=-1.0)
+            mjpl.RRT(model, joints, cr, max_planning_time=0.0)
+            mjpl.RRT(model, joints, cr, max_planning_time=-1.0)
         with self.assertRaisesRegex(ValueError, "epsilon"):
-            mjpl.RRT(model, [], cr, epsilon=0.0)
-            mjpl.RRT(model, [], cr, epsilon=-1.0)
+            mjpl.RRT(model, joints, cr, epsilon=0.0)
+            mjpl.RRT(model, joints, cr, epsilon=-1.0)
         with self.assertRaisesRegex(ValueError, "max_connection_distance"):
-            mjpl.RRT(model, [], cr, max_connection_distance=0.0)
-            mjpl.RRT(model, [], cr, max_connection_distance=-1.0)
+            mjpl.RRT(model, joints, cr, max_connection_distance=0.0)
+            mjpl.RRT(model, joints, cr, max_connection_distance=-1.0)
         with self.assertRaisesRegex(ValueError, "goal_biasing_probability"):
-            mjpl.RRT(model, [], cr, goal_biasing_probability=-1.0)
-            mjpl.RRT(model, [], cr, goal_biasing_probability=2.0)
+            mjpl.RRT(model, joints, cr, goal_biasing_probability=-1.0)
+            mjpl.RRT(model, joints, cr, goal_biasing_probability=2.0)
+        with self.assertRaisesRegex(ValueError, "planning_joints"):
+            mjpl.RRT(model, [], cr)
 
 
 if __name__ == "__main__":

--- a/test/test_ruckig_trajectory.py
+++ b/test/test_ruckig_trajectory.py
@@ -28,7 +28,9 @@ class TestRuckigTrajectoryGenerator(unittest.TestCase):
             rng.random(dof),
             rng.random(dof),
         ]
-        path = mjpl.types.Path(q_init=waypoints[0], waypoints=waypoints, joints=[])
+        path = mjpl.types.Path(
+            q_init=waypoints[0], waypoints=waypoints, joints=["dummy_joint"]
+        )
 
         t = traj_generator.generate_trajectory(path)
         np.testing.assert_equal(t.q_init, path.q_init)

--- a/test/test_toppra_trajectory.py
+++ b/test/test_toppra_trajectory.py
@@ -29,7 +29,9 @@ class TestToppraTrajectoryGenerator(unittest.TestCase):
             rng.random(dof),
             rng.random(dof),
         ]
-        path = mjpl.types.Path(q_init=waypoints[0], waypoints=waypoints, joints=[])
+        path = mjpl.types.Path(
+            q_init=waypoints[0], waypoints=waypoints, joints=["dummy_joint"]
+        )
 
         t = traj_generator.generate_trajectory(path)
         np.testing.assert_equal(t.q_init, path.q_init)

--- a/test/test_trajectory_utils.py
+++ b/test/test_trajectory_utils.py
@@ -22,7 +22,7 @@ class TestTrajectoryUtils(unittest.TestCase):
         positions_array = self.spline(np.linspace(0, 1, num_trajectory_points))
         self.trajectory = Trajectory(
             q_init=positions_array[0],
-            joints=[],
+            joints=["dummy_joint"],
             dt=1 / num_trajectory_points,
             positions=[row for row in positions_array],
             velocities=[],


### PR DESCRIPTION
In #71, I made the convention an empty list means all joints for things like the `Path` type, because I wasn't sure how to get all joint names from a model. Turns out that's actually pretty easy though, so I added a method for getting all joints in a model and also made it so that joints must be explicitly defined throughout the codebase.