### PR TITLE
ignore visualization.py in coverage report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,8 @@ ignore = [
   # Line too long.
   "E501"
 ]
+
+[tool.coverage.report]
+omit = [
+  "*visualization.py",
+]


### PR DESCRIPTION
I forgot to do this in #93 

`visualization.py` contains helper functions that are meant to be used with things like the MuJoCo viewer. Adding automated tests for visualization/UI like this is not worth the hassle, so this file should be ignored in the coverage report.