### PR TITLE
Simplify sink node emulation

### DIFF
--- a/src/mjpl/planning/rrt.py
+++ b/src/mjpl/planning/rrt.py
@@ -172,9 +172,9 @@ class RRT:
 
         start_tree = Tree(Node(q_init))
         # To support multiple goals, the root of the goal tree is a sink node and all
-        # goal configs are children of this sink node. Setting the sink node to a
-        # configuration of infinity emulates exclusion from nearest neighbor search in
-        # the tree, since the distance to the sink node's configuration is infinity.
+        # goal configurations are children of this sink node. Setting the sink node to a
+        # configuration with all values being infinity emulates exclusion from nearest
+        # neighbor search in the tree, since the distance to this node is infinity.
         sink_node = Node(np.ones_like(q_init) * np.inf)
         goal_nodes = [Node(q, sink_node) for q in q_goals]
         goal_tree = Tree(sink_node)
@@ -219,8 +219,7 @@ class RRT:
                     goal_tree,
                     goal_tree.nearest_neighbor(q_reached_a),
                 )
-                # Ignore the last value (infinity) which corresponds to  the sink node
-                # in the goal tree).
+                # Ignore the last value which corresponds to the goal tree's sink node.
                 return waypoints[:-1]
 
             # Swap trees.

--- a/src/mjpl/planning/rrt.py
+++ b/src/mjpl/planning/rrt.py
@@ -171,12 +171,13 @@ class RRT:
                 return [q_init, q]
 
         start_tree = Tree(Node(q_init))
-        # To support multiple goals, the root of the goal tree is a sink node
-        # (i.e., a node with an empty numpy array) and all goal configs are
-        # children of this sink node.
-        sink_node = Node(np.array([]))
+        # To support multiple goals, the root of the goal tree is a sink node and all
+        # goal configs are children of this sink node. Setting the sink node to a
+        # configuration of infinity emulates exclusion from nearest neighbor search in
+        # the tree, since the distance to the sink node's configuration is infinity.
+        sink_node = Node(np.ones_like(q_init) * np.inf)
         goal_nodes = [Node(q, sink_node) for q in q_goals]
-        goal_tree = Tree(sink_node, is_sink=True)
+        goal_tree = Tree(sink_node)
         for n in goal_nodes:
             goal_tree.add_node(n)
 
@@ -212,12 +213,15 @@ class RRT:
                 self.constraints,
             )
             if np.array_equal(q_reached_a, q_reached_b):
-                return _combine_paths(
+                waypoints = _combine_paths(
                     start_tree,
                     start_tree.nearest_neighbor(q_reached_a),
                     goal_tree,
                     goal_tree.nearest_neighbor(q_reached_a),
                 )
+                # Ignore the last value (infinity) which corresponds to  the sink node
+                # in the goal tree).
+                return waypoints[:-1]
 
             # Swap trees.
             tree_a, tree_b = tree_b, tree_a

--- a/src/mjpl/planning/tree.py
+++ b/src/mjpl/planning/tree.py
@@ -26,22 +26,15 @@ class Node:
 class Tree:
     """Tree of nodes."""
 
-    def __init__(self, root: Node, is_sink: bool = False):
+    def __init__(self, root: Node):
         """Constructor.
 
         Args:
             root: The tree's root node, which should have no parent.
-            is_sink: Whether or not the root node is a sink node. A sink node
-                is part of the tree, but ignored in `nearest_neighbor` and
-                `get_path`.
         """
         if root.parent:
             raise ValueError("The root node should have no parent.")
         self.nodes = {root}
-        self.sink_node = root if is_sink else None
-
-    def _is_sink(self, node: Node) -> bool:
-        return self.sink_node is not None and node == self.sink_node
 
     def add_node(self, node: Node):
         """Add a node to a tree.
@@ -69,20 +62,11 @@ class Tree:
 
         Returns: The node from the tree that's closest to `q`.
         """
-        closest_node = min(
-            self.nodes,
-            key=lambda node: (
-                np.inf if self._is_sink(node) else np.linalg.norm(node.q - q)
-            ),
-        )
-        if self._is_sink(closest_node):
-            raise RuntimeError(
-                "Tree contains no valid nodes for nearest neighbor search."
-            )
+        closest_node = min(self.nodes, key=lambda node: np.linalg.norm(node.q - q))
         return closest_node
 
     def get_path(self, node: Node) -> list[Node]:
-        """Get the path from the given node to its non-sink root.
+        """Get the path from the given node to the tree's root.
 
         Args:
             node: The node that defines the start of the path.
@@ -95,7 +79,7 @@ class Tree:
 
         path = []
         curr_node = node
-        while curr_node is not None and not self._is_sink(curr_node):
+        while curr_node is not None:
             path.append(curr_node)
             curr_node = curr_node.parent
         return path

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -21,7 +21,6 @@ class TestNode(unittest.TestCase):
 class TestTree(unittest.TestCase):
     def build_tree(self) -> Tree:
         tree = Tree(self.root)
-        self.assertIsNone(tree.sink_node)
         nodes = [self.n_1, self.n_2, self.n_3]
         for n in nodes:
             tree.add_node(n)
@@ -105,36 +104,6 @@ class TestTree(unittest.TestCase):
 
         path = tree.get_path(self.root)
         self.assertListEqual(path, [self.root])
-
-    def test_sink_node(self):
-        tree = Tree(self.root, is_sink=True)
-        self.assertIsNotNone(tree.sink_node)
-
-        # Sink node is not used in nearest neighbor
-        with self.assertRaisesRegex(
-            RuntimeError, "Tree contains no valid nodes for nearest neighbor"
-        ):
-            tree.nearest_neighbor(np.array([1]))
-
-        # Sink node is considered a part of the tree
-        sink_duplicate = Node(tree.sink_node.q, self.root)
-        self.assertIn(sink_duplicate, tree)
-        with self.assertRaisesRegex(ValueError, "already exists in the tree"):
-            tree.add_node(sink_duplicate)
-
-        # Sink node is not used in nearest neighbor, so make sure that calling
-        # nearest neighbor with a q that matches the sink node's q returns the
-        # nearest node that is NOT the sink node
-        tree.add_node(self.n_1)
-        nn = tree.nearest_neighbor(tree.sink_node.q)
-        self.assertNotEqual(nn, tree.sink_node)
-        self.assertEqual(nn, self.n_1)
-
-        # Sink node should be ignored in get_path
-        path = tree.get_path(tree.sink_node)
-        self.assertEqual(len(path), 0)
-        path = tree.get_path(self.n_1)
-        self.assertListEqual(path, [self.n_1])
 
 
 if __name__ == "__main__":

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -17,6 +17,9 @@ class TestNode(unittest.TestCase):
         self.assertNotEqual(b, c)
         self.assertEqual(c, d)
 
+        # Properly handle non-Node types.
+        self.assertNotEqual(a, 5)
+
 
 class TestTree(unittest.TestCase):
     def build_tree(self) -> Tree:


### PR DESCRIPTION
This removes the need for explicit handling/checking of a sink node in the `Tree` class by making a sink node (in RRT) one that has a configuration with all values set to infinity. By doing this, nearest neighbor search always computes infinity for this node, which effectively ignores it when other nodes are present in the tree.