### PR TITLE
Update ruff check alias in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.10
     hooks:
-      - id: ruff
+      - id: ruff-check
       - id: ruff-format
 
   - repo: local
@@ -18,7 +18,7 @@ repos:
 ci:
   autofix_commit_msg: |
    [pre-commit.ci] auto fixes from pre-commit.com hooks
-   
+
    for more information, see https://pre-commit.ci
   autofix_prs: true
   autoupdate_branch: ''


### PR DESCRIPTION
The alias for `ruff check` was updated with the version update introduced in #98 (I didn't realize this until after #98 was merged)