### PR TITLE
Add collision checking along an interval between two configs

### DIFF
--- a/src/mjpl/planning/cartesian_planner.py
+++ b/src/mjpl/planning/cartesian_planner.py
@@ -77,10 +77,6 @@ def cartesian_plan(
     """
     if not site:
         raise ValueError("`site` must be defined.")
-    if collision_interval_check is not None and collision_interval_check[0] <= 0:
-        raise ValueError(
-            "If `collision_interval_check` is defined, the check distance must be > 0."
-        )
 
     interpolated_poses = [poses[0]]
     for i in range(len(poses) - 1):

--- a/src/mjpl/planning/cartesian_planner.py
+++ b/src/mjpl/planning/cartesian_planner.py
@@ -1,9 +1,11 @@
 import numpy as np
 from mink.lie import SE3
 
+from ..constraint.collision_constraint import CollisionConstraint
 from ..constraint.constraint_interface import Constraint
 from ..constraint.utils import obeys_constraints
 from ..inverse_kinematics.ik_solver_interface import IKSolver
+from .utils import _valid_collision_interval
 
 
 def _interpolate_poses(
@@ -46,6 +48,7 @@ def cartesian_plan(
     site: str,
     solver: IKSolver,
     constraints: list[Constraint],
+    collision_interval_check: tuple[float, CollisionConstraint] | None = None,
     lin_threshold: float = 0.01,
     ori_threshold: float = 0.1,
 ) -> list[np.ndarray]:
@@ -57,6 +60,10 @@ def cartesian_plan(
         site: The site (i.e., frame) that should follow the Cartesian path.
         solver: Solver used to compute IK for `poses` and `site`.
         constraints: The constraints configurations in the Cartesian path must obey.
+        collision_interval_check: A tuple that defines the step distance and
+            CollisionConstraint that are used to check if the interval between two
+            configurations obeys the CollisionConstraint. Interval checking is disabled
+            if this is None.
         lin_threshold: The maximum linear distance (in meters) allowed between
             adjacent poses in `poses`. Pose interpolation will occur if this threshold
             is exceeded.
@@ -68,6 +75,13 @@ def cartesian_plan(
         A list of waypoints that adhere to a Cartesian path defined by `poses`,
         starting from `q_init`. If a path cannot be found, an empty list is returned.
     """
+    if not site:
+        raise ValueError("`site` must be defined.")
+    if collision_interval_check is not None and collision_interval_check[0] <= 0:
+        raise ValueError(
+            "If `collision_interval_check` is defined, the check distance must be > 0."
+        )
+
     interpolated_poses = [poses[0]]
     for i in range(len(poses) - 1):
         batch = _interpolate_poses(poses[i], poses[i + 1], lin_threshold, ori_threshold)
@@ -79,6 +93,15 @@ def cartesian_plan(
             q
             for q in solver.solve_ik(p, site, q_init_guess=waypoints[-1])
             if obeys_constraints(q, constraints)
+            and (
+                not collision_interval_check
+                or _valid_collision_interval(
+                    waypoints[-1],
+                    q,
+                    collision_interval_check[0],
+                    collision_interval_check[1],
+                )
+            )
         ]
         if not configs:
             return []

--- a/src/mjpl/planning/cartesian_planner.py
+++ b/src/mjpl/planning/cartesian_planner.py
@@ -91,8 +91,11 @@ def cartesian_plan(
             if obeys_constraints(q, constraints)
             and (
                 not collision_interval_check
+                # Include endpoints in interval collision checks since:
+                # 1. Interpolated poses may have been added
+                # 2. It is not guaranteed that IK solutions account for constraints
                 or _valid_collision_interval(
-                    waypoints[-1], q, *collision_interval_check
+                    waypoints[-1], q, *collision_interval_check, include_endpoints=True
                 )
             )
         ]

--- a/src/mjpl/planning/cartesian_planner.py
+++ b/src/mjpl/planning/cartesian_planner.py
@@ -92,10 +92,7 @@ def cartesian_plan(
             and (
                 not collision_interval_check
                 or _valid_collision_interval(
-                    waypoints[-1],
-                    q,
-                    collision_interval_check[0],
-                    collision_interval_check[1],
+                    waypoints[-1], q, *collision_interval_check
                 )
             )
         ]

--- a/src/mjpl/planning/cartesian_planner.py
+++ b/src/mjpl/planning/cartesian_planner.py
@@ -91,11 +91,8 @@ def cartesian_plan(
             if obeys_constraints(q, constraints)
             and (
                 not collision_interval_check
-                # Include endpoints in interval collision checks since:
-                # 1. Interpolated poses may have been added
-                # 2. It is not guaranteed that IK solutions account for constraints
                 or _valid_collision_interval(
-                    waypoints[-1], q, *collision_interval_check, include_endpoints=True
+                    waypoints[-1], q, *collision_interval_check
                 )
             )
         ]

--- a/src/mjpl/planning/rrt.py
+++ b/src/mjpl/planning/rrt.py
@@ -5,6 +5,7 @@ import numpy as np
 from mink.lie.se3 import SE3
 
 from .. import utils
+from ..constraint.collision_constraint import CollisionConstraint
 from ..constraint.constraint_interface import Constraint
 from ..constraint.utils import obeys_constraints
 from ..inverse_kinematics.ik_solver_interface import IKSolver
@@ -24,6 +25,7 @@ class RRT:
         model: mujoco.MjModel,
         planning_joints: list[str],
         constraints: list[Constraint],
+        collision_interval_check: tuple[float, CollisionConstraint] | None = None,
         max_planning_time: float = 10.0,
         epsilon: float = 0.05,
         seed: int | None = None,
@@ -35,25 +37,34 @@ class RRT:
             model: MuJoCo model.
             planning_joints: The joints that are sampled during planning.
             constraints: The constraints the sampled configurations must obey.
+            collision_interval_check: A tuple that defines the step distance and
+                CollisionConstraint that are used to check if the interval between two
+                configurations obeys the CollisionConstraint. Interval checking is
+                disabled if this is None.
             max_planning_time: Maximum planning time, in seconds.
             epsilon: The maximum distance allowed between nodes in the tree.
             seed: Seed used for the underlying sampler in the planner.
                 `None` means the algorithm is nondeterministc.
             goal_biasing_probability: Probability of sampling a goal state during planning.
-                This must be a value between [0.0, 1.0].
+                This must be a value between [0, 1].
         """
         if not planning_joints:
             raise ValueError("`planning_joints` cannot be empty.")
-        if max_planning_time <= 0.0:
-            raise ValueError("`max_planning_time` must be > 0.0")
-        if epsilon <= 0.0:
+        if collision_interval_check is not None and collision_interval_check[0] <= 0:
+            raise ValueError(
+                "If `collision_interval_check` is defined, the check distance must be > 0."
+            )
+        if max_planning_time <= 0:
+            raise ValueError("`max_planning_time` must be > 0")
+        if epsilon <= 0:
             raise ValueError("`epsilon` must be > 0.0")
-        if goal_biasing_probability < 0.0 or goal_biasing_probability > 1.0:
-            raise ValueError("`goal_biasing_probability` must be within [0.0, 1.0].")
+        if goal_biasing_probability < 0 or goal_biasing_probability > 1:
+            raise ValueError("`goal_biasing_probability` must be within [0, 1].")
 
         self.model = model
         self.planning_joints = planning_joints
         self.constraints = constraints
+        self.collision_interval_check = collision_interval_check
         self.max_planning_time = max_planning_time
         self.epsilon = epsilon
         self.seed = seed
@@ -204,12 +215,14 @@ class RRT:
                 tree_a,
                 self.epsilon,
                 self.constraints,
+                self.collision_interval_check,
             )
             q_reached_b = _constrained_extend(
                 q_reached_a,
                 tree_b,
                 self.epsilon,
                 self.constraints,
+                self.collision_interval_check,
             )
             if np.array_equal(q_reached_a, q_reached_b):
                 waypoints = _combine_paths(

--- a/src/mjpl/planning/rrt.py
+++ b/src/mjpl/planning/rrt.py
@@ -54,11 +54,11 @@ class RRT:
             raise ValueError(
                 "If `collision_interval_check` is defined, the check distance must be > 0."
             )
-        if max_planning_time <= 0:
+        if max_planning_time <= 0.0:
             raise ValueError("`max_planning_time` must be > 0")
-        if epsilon <= 0:
-            raise ValueError("`epsilon` must be > 0.0")
-        if goal_biasing_probability < 0 or goal_biasing_probability > 1:
+        if epsilon <= 0.0:
+            raise ValueError("`epsilon` must be > 0")
+        if goal_biasing_probability < 0.0 or goal_biasing_probability > 1.0:
             raise ValueError("`goal_biasing_probability` must be within [0, 1].")
 
         self.model = model

--- a/src/mjpl/planning/rrt.py
+++ b/src/mjpl/planning/rrt.py
@@ -46,16 +46,16 @@ class RRT:
             seed: Seed used for the underlying sampler in the planner.
                 `None` means the algorithm is nondeterministc.
             goal_biasing_probability: Probability of sampling a goal state during planning.
-                This must be a value between [0, 1].
+                This must be a value between [0.0, 1.0].
         """
         if not planning_joints:
             raise ValueError("`planning_joints` cannot be empty.")
         if max_planning_time <= 0.0:
-            raise ValueError("`max_planning_time` must be > 0")
+            raise ValueError("`max_planning_time` must be > 0.0")
         if epsilon <= 0.0:
-            raise ValueError("`epsilon` must be > 0")
+            raise ValueError("`epsilon` must be > 0.0")
         if goal_biasing_probability < 0.0 or goal_biasing_probability > 1.0:
-            raise ValueError("`goal_biasing_probability` must be within [0, 1].")
+            raise ValueError("`goal_biasing_probability` must be within [0.0, 1.0].")
 
         self.model = model
         self.planning_joints = planning_joints

--- a/src/mjpl/planning/rrt.py
+++ b/src/mjpl/planning/rrt.py
@@ -60,13 +60,7 @@ class RRT:
         self.model = model
         self.planning_joints = planning_joints
         self.constraints = constraints
-        # The RRT algorithm applies constraints to each new sampled configuration. This
-        # means the endpoints of all intervals can be ignored in interval collision checks.
-        self.collision_interval_check = (
-            None
-            if collision_interval_check is None
-            else (collision_interval_check[0], collision_interval_check[1], False)
-        )
+        self.collision_interval_check = collision_interval_check
         self.max_planning_time = max_planning_time
         self.epsilon = epsilon
         self.seed = seed

--- a/src/mjpl/planning/rrt.py
+++ b/src/mjpl/planning/rrt.py
@@ -50,10 +50,6 @@ class RRT:
         """
         if not planning_joints:
             raise ValueError("`planning_joints` cannot be empty.")
-        if collision_interval_check is not None and collision_interval_check[0] <= 0:
-            raise ValueError(
-                "If `collision_interval_check` is defined, the check distance must be > 0."
-            )
         if max_planning_time <= 0.0:
             raise ValueError("`max_planning_time` must be > 0")
         if epsilon <= 0.0:

--- a/src/mjpl/planning/rrt.py
+++ b/src/mjpl/planning/rrt.py
@@ -60,7 +60,13 @@ class RRT:
         self.model = model
         self.planning_joints = planning_joints
         self.constraints = constraints
-        self.collision_interval_check = collision_interval_check
+        # The RRT algorithm applies constraints to each new sampled configuration. This
+        # means the endpoints of all intervals can be ignored in interval collision checks.
+        self.collision_interval_check = (
+            None
+            if collision_interval_check is None
+            else (collision_interval_check[0], collision_interval_check[1], False)
+        )
         self.max_planning_time = max_planning_time
         self.epsilon = epsilon
         self.seed = seed

--- a/src/mjpl/planning/utils.py
+++ b/src/mjpl/planning/utils.py
@@ -43,10 +43,6 @@ def smooth_path(
     """
     if not waypoints:
         raise ValueError("`waypoints` cannot be empty.")
-    if collision_interval_check is not None and collision_interval_check[0] <= 0:
-        raise ValueError(
-            "If `collision_interval_check` is defined, the check distance must be > 0."
-        )
     if eps <= 0.0:
         raise ValueError("`eps` must be > 0.")
     if num_tries <= 0:
@@ -197,6 +193,9 @@ def _valid_collision_interval(
     step_dist: float,
     constraint: CollisionConstraint,
 ) -> bool:
+    if step_dist <= 0.0:
+        raise ValueError("`step_dist` must be > 0")
+
     curr = start
     while not np.array_equal(curr, end):
         if not constraint.valid_config(curr):

--- a/src/mjpl/planning/utils.py
+++ b/src/mjpl/planning/utils.py
@@ -48,6 +48,15 @@ def smooth_path(
     if num_tries <= 0:
         raise ValueError("`num_tries` must be > 0.")
 
+    # Assume waypoints don't violate the CollisionConstraint since they come from a
+    # pre-defined path. This means the endpoints of all intervals can be ignored in
+    # interval collision checks.
+    _collision_interval_check = (
+        None
+        if collision_interval_check is None
+        else (collision_interval_check[0], collision_interval_check[1], False)
+    )
+
     smoothed_path = waypoints
     rng = np.random.default_rng(seed=seed)
     for _ in range(num_tries):
@@ -59,7 +68,7 @@ def smooth_path(
         # constraints.
         tree = Tree(Node(smoothed_path[start]))
         q_reached = _constrained_extend(
-            smoothed_path[end], tree, eps, constraints, collision_interval_check
+            smoothed_path[end], tree, eps, constraints, _collision_interval_check
         )
         if not np.array_equal(q_reached, smoothed_path[end]):
             continue
@@ -107,7 +116,7 @@ def _constrained_extend(
     tree: Tree,
     eps: float,
     constraints: list[Constraint],
-    collision_interval_check: tuple[float, CollisionConstraint] | None = None,
+    collision_interval_check: tuple[float, CollisionConstraint, bool] | None = None,
     equality_threshold: float = 1e-8,
 ) -> np.ndarray:
     """Extend a tree towards a target configuration, subject to constraints.
@@ -120,10 +129,10 @@ def _constrained_extend(
         tree: The tree to extend towards `q_target`.
         eps: The maximum distance allowed between nodes in `tree`.
         constraints: The constraints nodes in `tree` must obey.
-        collision_interval_check: A tuple that defines the step distance and
-            CollisionConstraint that are used to check if the interval between two
-            configurations obeys the CollisionConstraint. Interval checking is disabled
-            if this is None.
+        collision_interval_check: A tuple that defines the step distance,
+            CollisionConstraint, and whether or not endpoints are included when checking
+            if the interval between two configurations obeys the CollisionConstraint.
+            Interval checking is disabled if this is None.
         equality_threshold: Configuration distance threshold for determining whether or
             not a constrained configuration is equivalent to its previous configuration.
             Used as termination criteria for handling things like local minima in
@@ -190,16 +199,30 @@ def _valid_collision_interval(
     end: np.ndarray,
     step_dist: float,
     constraint: CollisionConstraint,
+    include_endpoints: bool,
 ) -> bool:
+    """Check if configurations at a discrete step over an interval obey a CollisionConstraint.
+
+    Args:
+        start: The configuration that marks the start of the interval.
+        end: The configuration that marks the end of the interval.
+        step_dist: The distance to step towards `end` from `start`.
+        constraint: The CollisionConstraint that configurations in the interval must obey.
+        include_endpoints: Whether or not `start` and `end` should be included in the check.
+
+    Returns:
+        True if the configurations over the interval obey `constraint`. False otherwise.
+    """
     if step_dist <= 0.0:
         raise ValueError("`step_dist` must be > 0")
 
-    curr = start
-    while not np.array_equal(curr, end):
-        if not constraint.valid_config(curr):
-            return False
-        curr = _step(curr, end, step_dist)
-    return True
+    waypoints = [start]
+    while not np.array_equal(waypoints[-1], end):
+        waypoints.append(_step(waypoints[-1], end, step_dist))
+    if not include_endpoints:
+        waypoints = waypoints[1:-1]
+
+    return all(constraint.valid_config(wp) for wp in waypoints)
 
 
 def _combine_paths(

--- a/src/mjpl/planning/utils.py
+++ b/src/mjpl/planning/utils.py
@@ -154,9 +154,7 @@ def _constrained_extend(
             or np.linalg.norm(q_target - q) > np.linalg.norm(q_target - q_old)
             or (
                 collision_interval_check is not None
-                and not _valid_collision_interval(
-                    q, q_old, collision_interval_check[0], collision_interval_check[1]
-                )
+                and not _valid_collision_interval(q, q_old, *collision_interval_check)
             )
         ):
             return q_old

--- a/src/mjpl/planning/utils.py
+++ b/src/mjpl/planning/utils.py
@@ -41,6 +41,12 @@ def smooth_path(
     Returns:
         A smoothed path based on `waypoints` that obeys `constraints`.
     """
+    if not waypoints:
+        raise ValueError("`waypoints` cannot be empty.")
+    if collision_interval_check is not None and collision_interval_check[0] <= 0:
+        raise ValueError(
+            "If `collision_interval_check` is defined, the check distance must be > 0."
+        )
     if eps <= 0.0:
         raise ValueError("`eps` must be > 0.")
     if num_tries <= 0:

--- a/src/mjpl/planning/utils.py
+++ b/src/mjpl/planning/utils.py
@@ -154,7 +154,7 @@ def _constrained_extend(
             or np.linalg.norm(q_target - q) > np.linalg.norm(q_target - q_old)
             or (
                 collision_interval_check is not None
-                and not _valid_collision_interval(q, q_old, *collision_interval_check)
+                and not _valid_collision_interval(q_old, q, *collision_interval_check)
             )
         ):
             return q_old

--- a/test/models/one_dof_ball.xml
+++ b/test/models/one_dof_ball.xml
@@ -5,10 +5,10 @@
 
     <body name="ball" pos="0 0 1">
       <joint name="ball_slide_x" type="slide" axis="1 0 0" range="-1 1"/>
-      <geom type="sphere" size="0.1" rgba="0 1 0 1"/>
+      <geom type="sphere" size="0.01" rgba="0 1 0 1"/>
     </body>
 
-    <!-- Obstacle that lies from x = 0.8 .. 1 -->
-    <geom name="wall_obstacle" type="box" pos="0.9 0 1" size="0.1 0.5 0.5" rgba="1 0 0 1"/>
+    <!-- Obstacle that lies from x = 0.85 .. 0.95 -->
+    <geom name="wall_obstacle" type="box" pos="0.9 0 1" size="0.05 0.5 0.5" rgba="1 0 0 1"/>
   </worldbody>
 </mujoco>

--- a/test/models/one_dof_ball.xml
+++ b/test/models/one_dof_ball.xml
@@ -4,7 +4,7 @@
     <geom type="plane" size="2 2 0.1" rgba=".75 .75 .75 1"/>
 
     <body name="ball" pos="0 0 1">
-      <joint name="ball_slide_x" type="slide" axis="1 0 0" range="-1 1"/>
+      <joint name="ball_slide_x" type="slide" axis="1 0 0" range="-2 2"/>
       <geom type="sphere" size="0.01" rgba="0 1 0 1"/>
     </body>
 

--- a/test/test_cartesian_planner.py
+++ b/test/test_cartesian_planner.py
@@ -192,6 +192,20 @@ class TestCartesianPlanner(unittest.TestCase):
         self.assertLessEqual(np.linalg.norm(err[:3]), pos_tolerance)
         self.assertLessEqual(np.linalg.norm(err[3:]), ori_tolerance)
 
+    def test_invalid_args(self):
+        model = load_robot_description("ur5e_mj_description")
+        q_init = model.keyframe("home").qpos
+        site = "attachment_site"
+        solver = mjpl.MinkIKSolver(model, mjpl.all_joints(model))
+
+        with self.assertRaisesRegex(ValueError, "site"):
+            mjpl.cartesian_plan(q_init, [], "", solver, [])
+
+        constraint = mjpl.CollisionConstraint(model)
+        with self.assertRaisesRegex(ValueError, "collision_interval_check"):
+            mjpl.cartesian_plan(q_init, [], site, solver, [], (0.0, constraint))
+            mjpl.cartesian_plan(q_init, [], site, solver, [], (-1.0, constraint))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_cartesian_planner.py
+++ b/test/test_cartesian_planner.py
@@ -195,16 +195,10 @@ class TestCartesianPlanner(unittest.TestCase):
     def test_invalid_args(self):
         model = load_robot_description("ur5e_mj_description")
         q_init = model.keyframe("home").qpos
-        site = "attachment_site"
         solver = mjpl.MinkIKSolver(model, mjpl.all_joints(model))
 
         with self.assertRaisesRegex(ValueError, "site"):
             mjpl.cartesian_plan(q_init, [], "", solver, [])
-
-        constraint = mjpl.CollisionConstraint(model)
-        with self.assertRaisesRegex(ValueError, "collision_interval_check"):
-            mjpl.cartesian_plan(q_init, [], site, solver, [], (0.0, constraint))
-            mjpl.cartesian_plan(q_init, [], site, solver, [], (-1.0, constraint))
 
 
 if __name__ == "__main__":

--- a/test/test_planning_utils.py
+++ b/test/test_planning_utils.py
@@ -185,12 +185,7 @@ class TestPlanningUtils(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "waypoints"):
             mjpl.smooth_path([], [])
 
-        model = mujoco.MjModel.from_xml_path(_ONE_DOF_BALL_XML.as_posix())
-        constraint = mjpl.CollisionConstraint(model)
         waypoints = [np.zeros((6,)), np.ones((6,))]
-        with self.assertRaisesRegex(ValueError, "collision_interval_check"):
-            mjpl.smooth_path(waypoints, [], collision_interval_check=(0.0, constraint))
-            mjpl.smooth_path(waypoints, [], collision_interval_check=(-1.0, constraint))
 
         with self.assertRaisesRegex(ValueError, "eps"):
             mjpl.smooth_path(waypoints, [], eps=0.0)
@@ -344,6 +339,10 @@ class TestPlanningUtils(unittest.TestCase):
         end = np.array([0.2])
         self.assertTrue(_valid_collision_interval(start, end, 0.01, constraint))
         self.assertTrue(_valid_collision_interval(start, end, 0.5, constraint))
+
+        with self.assertRaisesRegex(ValueError, "step_dist"):
+            _valid_collision_interval(start, end, 0.0, constraint)
+            _valid_collision_interval(start, end, -1.0, constraint)
 
     def test_combine_paths(self):
         root_start = Node(np.array([0.0]))

--- a/test/test_planning_utils.py
+++ b/test/test_planning_utils.py
@@ -269,14 +269,14 @@ class TestPlanningUtils(unittest.TestCase):
 
         # Test a constrained extend between two configurations that obey the planning
         # constraints, but violate the collision interval check.
-        # If the collision interval step distance is large enough, the interval should
-        # "skip over" the obstacle and succeed.
+        # If the collision interval step distance is large enough, the interval check
+        # should "skip over" the obstacle and succeed.
         tree = Tree(Node(q_init))
         q_reached = _constrained_extend(
             q_goal, tree, np.inf, constraints, (np.inf, collision_constraint)
         )
         np.testing.assert_equal(q_reached, q_goal)
-        # If the collision interval step distance is small, the interval should
+        # If the collision interval step distance is small, the interval check should
         # intersect with the obstacle and fail.
         tree = Tree(Node(q_init))
         q_reached = _constrained_extend(

--- a/test/test_planning_utils.py
+++ b/test/test_planning_utils.py
@@ -273,14 +273,14 @@ class TestPlanningUtils(unittest.TestCase):
         # should "skip over" the obstacle and succeed.
         tree = Tree(Node(q_init))
         q_reached = _constrained_extend(
-            q_goal, tree, np.inf, constraints, (np.inf, collision_constraint, False)
+            q_goal, tree, np.inf, constraints, (np.inf, collision_constraint)
         )
         np.testing.assert_equal(q_reached, q_goal)
         # If the collision interval step distance is small, the interval check should
         # intersect with the obstacle and fail.
         tree = Tree(Node(q_init))
         q_reached = _constrained_extend(
-            q_goal, tree, np.inf, constraints, (0.1, collision_constraint, False)
+            q_goal, tree, np.inf, constraints, (0.1, collision_constraint)
         )
         np.testing.assert_equal(q_reached, q_init)
 
@@ -322,51 +322,26 @@ class TestPlanningUtils(unittest.TestCase):
         model = mujoco.MjModel.from_xml_path(_ONE_DOF_BALL_XML.as_posix())
         constraint = mjpl.CollisionConstraint(model)
 
-        # Interval with valid endpoints that passes through an obstacle.
+        # Interval that passes through an obstacle.
         start = np.array([0.8])
-        end = np.array([1.0])
-        self.assertTrue(constraint.valid_config(start))
-        self.assertTrue(constraint.valid_config(end))
+        end = np.array([1.5])
 
         # The collision violation should be detected with a step size that intersects
         # with the obstacle.
-        self.assertFalse(_valid_collision_interval(start, end, 0.1, constraint, True))
-        self.assertFalse(_valid_collision_interval(start, end, 0.1, constraint, False))
+        self.assertFalse(_valid_collision_interval(start, end, 0.1, constraint))
 
         # The collision violation should NOT be detected with a step size that skips
         # the obstacle.
-        self.assertTrue(_valid_collision_interval(start, end, 0.5, constraint, True))
-        self.assertTrue(_valid_collision_interval(start, end, 0.5, constraint, False))
+        self.assertTrue(_valid_collision_interval(start, end, 0.2, constraint))
 
-        # Interval with valid endpoints that does not pass through an obstacle.
+        # Interval that does not pass through an obstacle.
         start = np.array([0.0])
         end = np.array([0.2])
-        self.assertTrue(constraint.valid_config(start))
-        self.assertTrue(constraint.valid_config(end))
-        self.assertTrue(_valid_collision_interval(start, end, 0.01, constraint, True))
-        self.assertTrue(_valid_collision_interval(start, end, 0.01, constraint, False))
-        self.assertTrue(_valid_collision_interval(start, end, 0.5, constraint, True))
-        self.assertTrue(_valid_collision_interval(start, end, 0.5, constraint, False))
-
-        # Interval with invalid start point.
-        start = np.array([0.85])
-        end = np.array([1.5])
-        self.assertFalse(constraint.valid_config(start))
-        self.assertTrue(constraint.valid_config(end))
-        self.assertFalse(_valid_collision_interval(start, end, 0.15, constraint, True))
-        self.assertTrue(_valid_collision_interval(start, end, 0.15, constraint, False))
-
-        # Interval with invalid last point.
-        start = np.array([0.5])
-        end = np.array([0.85])
-        self.assertTrue(constraint.valid_config(start))
-        self.assertFalse(constraint.valid_config(end))
-        self.assertFalse(_valid_collision_interval(start, end, 0.2, constraint, True))
-        self.assertTrue(_valid_collision_interval(start, end, 0.2, constraint, False))
+        self.assertTrue(_valid_collision_interval(start, end, 0.01, constraint))
 
         with self.assertRaisesRegex(ValueError, "step_dist"):
-            _valid_collision_interval(start, end, 0.0, constraint, True)
-            _valid_collision_interval(start, end, -1.0, constraint, True)
+            _valid_collision_interval(start, end, 0.0, constraint)
+            _valid_collision_interval(start, end, -1.0, constraint)
 
     def test_combine_paths(self):
         root_start = Node(np.array([0.0]))

--- a/test/test_planning_utils.py
+++ b/test/test_planning_utils.py
@@ -181,6 +181,25 @@ class TestPlanningUtils(unittest.TestCase):
         for wp in smoothed_waypoints:
             self.assertTrue(mjpl.obeys_constraints(wp, constraints))
 
+    def test_smooth_path_invalid_args(self):
+        with self.assertRaisesRegex(ValueError, "waypoints"):
+            mjpl.smooth_path([], [])
+
+        model = mujoco.MjModel.from_xml_path(_ONE_DOF_BALL_XML.as_posix())
+        constraint = mjpl.CollisionConstraint(model)
+        waypoints = [np.zeros((6,)), np.ones((6,))]
+        with self.assertRaisesRegex(ValueError, "collision_interval_check"):
+            mjpl.smooth_path(waypoints, [], collision_interval_check=(0.0, constraint))
+            mjpl.smooth_path(waypoints, [], collision_interval_check=(-1.0, constraint))
+
+        with self.assertRaisesRegex(ValueError, "eps"):
+            mjpl.smooth_path(waypoints, [], eps=0.0)
+            mjpl.smooth_path(waypoints, [], eps=-1.0)
+
+        with self.assertRaisesRegex(ValueError, "num_tries"):
+            mjpl.smooth_path(waypoints, [], num_tries=0)
+            mjpl.smooth_path(waypoints, [], num_tries=-1)
+
     def test_path_length(self):
         waypoints = [
             np.array([0.0, 0.0, 0.0]),

--- a/test/test_planning_utils.py
+++ b/test/test_planning_utils.py
@@ -263,7 +263,7 @@ class TestPlanningUtils(unittest.TestCase):
         ]
 
         q_init = np.array([0.8])
-        q_goal = np.array([1.0])
+        q_goal = np.array([1.8])
         self.assertTrue(mjpl.obeys_constraints(q_init, constraints))
         self.assertTrue(mjpl.obeys_constraints(q_goal, constraints))
 
@@ -273,7 +273,7 @@ class TestPlanningUtils(unittest.TestCase):
         # should "skip over" the obstacle and succeed.
         tree = Tree(Node(q_init))
         q_reached = _constrained_extend(
-            q_goal, tree, np.inf, constraints, (np.inf, collision_constraint)
+            q_goal, tree, np.inf, constraints, (0.3, collision_constraint)
         )
         np.testing.assert_equal(q_reached, q_goal)
         # If the collision interval step distance is small, the interval check should

--- a/test/test_rrt.py
+++ b/test/test_rrt.py
@@ -162,6 +162,19 @@ class TestRRT(unittest.TestCase):
             mjpl.RRT(model, joints, [], goal_biasing_probability=2.0)
         with self.assertRaisesRegex(ValueError, "planning_joints"):
             mjpl.RRT(model, [], [])
+        with self.assertRaisesRegex(ValueError, "collision_interval_check"):
+            mjpl.RRT(
+                model,
+                joints,
+                [],
+                collision_interval_check=(0.0, mjpl.CollisionConstraint(model)),
+            )
+            mjpl.RRT(
+                model,
+                joints,
+                [],
+                collision_interval_check=(-1.0, mjpl.CollisionConstraint(model)),
+            )
 
         model = mujoco.MjModel.from_xml_path(_TWO_DOF_BALL_XML.as_posix())
         joints = ["ball_slide_y"]

--- a/test/test_rrt.py
+++ b/test/test_rrt.py
@@ -162,19 +162,6 @@ class TestRRT(unittest.TestCase):
             mjpl.RRT(model, joints, [], goal_biasing_probability=2.0)
         with self.assertRaisesRegex(ValueError, "planning_joints"):
             mjpl.RRT(model, [], [])
-        with self.assertRaisesRegex(ValueError, "collision_interval_check"):
-            mjpl.RRT(
-                model,
-                joints,
-                [],
-                collision_interval_check=(0.0, mjpl.CollisionConstraint(model)),
-            )
-            mjpl.RRT(
-                model,
-                joints,
-                [],
-                collision_interval_check=(-1.0, mjpl.CollisionConstraint(model)),
-            )
 
         model = mujoco.MjModel.from_xml_path(_TWO_DOF_BALL_XML.as_posix())
         joints = ["ball_slide_y"]


### PR DESCRIPTION
When trying to extend trees in the RRT, it may be worth checking that the interval between two configurations doesn't violate collisions. If the planner's epsilon is small enough, this isn't really necessary - but for cluttered environments and/or larger epsilon values, doing this interval check is valuable.