### PR TITLE
Add `--service=github` flag to coveralls in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
         run: coverage run --source=src -m unittest -v
 
       - name: "Coveralls"
-        run: coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          coveralls --service=github


### PR DESCRIPTION
I am seeing duplicate coveralls checks in the PR workflows section (example image below). I think this should fix that.

![image](https://github.com/user-attachments/assets/0fabf9b6-7ce7-4b35-a2ae-a20fc7fd3ca7)
